### PR TITLE
settings page updates

### DIFF
--- a/components/LanguageBottomSheet.tsx
+++ b/components/LanguageBottomSheet.tsx
@@ -1,0 +1,200 @@
+import React, { forwardRef, useMemo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { FontAwesome6 } from '@expo/vector-icons';
+
+// Design system constants
+const CORAL = '#FF725E';
+const TEXT_DARK = '#1F2937';
+const TEXT_LIGHT = '#64748b';
+const BORDER_LIGHT = '#e2e8f0';
+const OFF_WHITE = '#FFF8F6';
+
+export interface LanguageBottomSheetProps {}
+
+export const LanguageBottomSheet = forwardRef<BottomSheetModal, LanguageBottomSheetProps>(
+  (props, ref) => {
+    // The heights the sheet can snap to
+    const snapPoints = useMemo(() => ['60%'], []);
+
+    const handleClose = () => {
+      (ref as React.RefObject<BottomSheetModal>)?.current?.dismiss();
+    };
+
+    return (
+      <BottomSheetModal
+        ref={ref}
+        index={0}
+        snapPoints={snapPoints}
+        handleIndicatorStyle={{ backgroundColor: BORDER_LIGHT }}
+        backgroundStyle={{ backgroundColor: OFF_WHITE }}
+      >
+        <BottomSheetScrollView contentContainerStyle={styles.contentContainer}>
+          {/* Header */}
+          <View style={styles.headerRow}>
+            <View style={styles.headerContent}>
+              <Text style={styles.title}>Idioma</Text>
+              <Text style={styles.subtitle}>Configurações de idioma</Text>
+            </View>
+            <TouchableOpacity onPress={handleClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+              <FontAwesome6 name="xmark" size={22} color={CORAL} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Current Language Card */}
+          <View style={styles.languageCard}>
+            <View style={styles.languageContent}>
+              <View style={styles.languageHeader}>
+                <View style={styles.languageInfo}>
+                  <FontAwesome6 name="globe" size={24} color={CORAL} />
+                  <View style={styles.languageText}>
+                    <Text style={styles.languageTitle}>Português (Brasil)</Text>
+                    <Text style={styles.languageSubtitle}>Idioma atual</Text>
+                  </View>
+                </View>
+                <View style={styles.activeBadge}>
+                  <Text style={styles.activeBadgeText}>ATIVO</Text>
+                </View>
+              </View>
+            </View>
+          </View>
+
+          {/* Information Card */}
+          <View style={styles.infoCard}>
+            <View style={styles.infoContent}>
+              <Text style={styles.infoTitle}>Informações sobre idiomas</Text>
+              
+              <Text style={styles.infoText}>
+                Atualmente, o ForkFit está disponível apenas em português brasileiro. 
+                Novos idiomas estarão disponíveis em breve!
+              </Text>
+
+              <View style={styles.separator} />
+
+              <Text style={styles.infoTitle}>Language Information</Text>
+              <Text style={styles.infoText}>
+                Currently, ForkFit is only available in Brazilian Portuguese. 
+                New languages will be available soon!
+              </Text>
+
+              <View style={styles.separator} />
+
+              <Text style={styles.infoTitle}>Información de idiomas</Text>
+              <Text style={styles.infoText}>
+                Actualmente, ForkFit solo está disponible en portugués brasileño. 
+                ¡Nuevos idiomas estarán disponibles pronto!
+              </Text>
+            </View>
+          </View>
+        </BottomSheetScrollView>
+      </BottomSheetModal>
+    );
+  }
+);
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 24,
+    paddingTop: 8,
+  },
+  headerContent: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: TEXT_DARK,
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: TEXT_LIGHT,
+  },
+  languageCard: {
+    backgroundColor: '#f8fafc',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: BORDER_LIGHT,
+    overflow: 'hidden',
+    marginBottom: 16,
+  },
+  languageContent: {
+    padding: 20,
+  },
+  languageHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  languageInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  languageText: {
+    marginLeft: 12,
+    flex: 1,
+  },
+  languageTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: TEXT_DARK,
+    marginBottom: 2,
+  },
+  languageSubtitle: {
+    fontSize: 14,
+    color: TEXT_LIGHT,
+  },
+  activeBadge: {
+    backgroundColor: '#10b981',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    minWidth: 60,
+    alignItems: 'center',
+  },
+  activeBadgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#ffffff',
+    textTransform: 'uppercase',
+  },
+  infoCard: {
+    backgroundColor: '#ffffff',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: BORDER_LIGHT,
+    overflow: 'hidden',
+    marginBottom: 16,
+  },
+  infoContent: {
+    padding: 20,
+  },
+  infoTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: TEXT_DARK,
+    marginBottom: 8,
+  },
+  infoText: {
+    fontSize: 14,
+    color: TEXT_LIGHT,
+    lineHeight: 20,
+    marginBottom: 16,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: BORDER_LIGHT,
+    marginVertical: 16,
+  },
+});
+
+LanguageBottomSheet.displayName = 'LanguageBottomSheet';

--- a/components/PrivacyBottomSheet.tsx
+++ b/components/PrivacyBottomSheet.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useCallback, useMemo } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Linking } from 'react-native';
 import { BottomSheetModal, BottomSheetScrollView, BottomSheetView } from '@gorhom/bottom-sheet';
 import { FontAwesome6 } from '@expo/vector-icons';
 
@@ -21,6 +21,22 @@ export const PrivacyBottomSheet = forwardRef<BottomSheetModal, PrivacyBottomShee
         ref.current.dismiss();
       }
     }, [ref]);
+
+    const handleOpenPrivacyPolicy = useCallback(async () => {
+      try {
+        await Linking.openURL('https://forkfit.app/politica-de-privacidade');
+      } catch (error) {
+        console.error('Error opening privacy policy:', error);
+      }
+    }, []);
+
+    const handleOpenTermsOfUse = useCallback(async () => {
+      try {
+        await Linking.openURL('https://forkfit.app/termos-de-uso');
+      } catch (error) {
+        console.error('Error opening terms of use:', error);
+      }
+    }, []);
 
     return (
       <BottomSheetModal
@@ -53,6 +69,9 @@ export const PrivacyBottomSheet = forwardRef<BottomSheetModal, PrivacyBottomShee
             <Text style={styles.sectionContent}>
               Levamos sua privacidade a sério. Coletamos apenas o essencial para oferecer uma boa experiência no ForkFit — como nome, e-mail e suas escolhas alimentares. Tudo é armazenado com segurança e nunca será compartilhado sem seu consentimento.
             </Text>
+            <TouchableOpacity onPress={handleOpenPrivacyPolicy} style={styles.linkButton}>
+              <Text style={styles.linkText}>Saiba mais aqui</Text>
+            </TouchableOpacity>
           </View>
 
           {/* Terms of Use Section */}
@@ -65,6 +84,9 @@ export const PrivacyBottomSheet = forwardRef<BottomSheetModal, PrivacyBottomShee
             <Text style={styles.sectionContent}>
               Ao usar o ForkFit, você concorda em registrar informações reais e usar o app apenas para fins pessoais. Não nos responsabilizamos por decisões médicas — sempre consulte um profissional de saúde.
             </Text>
+            <TouchableOpacity onPress={handleOpenTermsOfUse} style={styles.linkButton}>
+              <Text style={styles.linkText}>Saiba mais aqui</Text>
+            </TouchableOpacity>
           </View>
 
           {/* Contact Section */}
@@ -166,6 +188,17 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     color: '#666',
     marginLeft: 36, // Align with content after emoji
+    marginBottom: 12,
+  },
+  linkButton: {
+    marginLeft: 36, // Align with content after emoji
+    marginTop: 4,
+  },
+  linkText: {
+    fontSize: 14,
+    color: CORAL,
+    fontWeight: '500',
+    textDecorationLine: 'underline',
   },
   contactSection: {
     backgroundColor: '#f8f9fa',

--- a/components/SubscriptionBottomSheet.tsx
+++ b/components/SubscriptionBottomSheet.tsx
@@ -1,0 +1,337 @@
+import React, { forwardRef, useMemo, useState, useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { FontAwesome6 } from '@expo/vector-icons';
+import { useSubscription } from '../contexts/SubscriptionContext';
+
+// Design system constants
+const CORAL = '#FF725E';
+const TEXT_DARK = '#1F2937';
+const TEXT_LIGHT = '#64748b';
+const BORDER_LIGHT = '#e2e8f0';
+const OFF_WHITE = '#FFF8F6';
+
+export interface SubscriptionBottomSheetProps {}
+
+export const SubscriptionBottomSheet = forwardRef<BottomSheetModal, SubscriptionBottomSheetProps>(
+  (props, ref) => {
+    const { isPremium, customerInfo, subscriptionLoading, presentPaywall, refreshCustomerInfo } = useSubscription();
+    const [isPresentingPaywall, setIsPresentingPaywall] = useState(false);
+
+    // The heights the sheet can snap to
+    const snapPoints = useMemo(() => ['50%'], []);
+
+    // Handle paywall presentation
+    const handlePresentPaywall = async () => {
+      if (isPresentingPaywall) return;
+      
+      try {
+        setIsPresentingPaywall(true);
+        console.log('🎯 SubscriptionBottomSheet: Presenting paywall...');
+        
+        const success = await presentPaywall();
+        console.log('🎯 SubscriptionBottomSheet: Paywall result:', success);
+        
+        if (success) {
+          console.log('✅ SubscriptionBottomSheet: Subscription successful, refreshing data...');
+          
+          // Add a small delay to ensure RevenueCat has processed the purchase
+          setTimeout(async () => {
+            try {
+              console.log('🔄 SubscriptionBottomSheet: Refreshing customer info...');
+              await refreshCustomerInfo();
+              console.log('✅ SubscriptionBottomSheet: Customer info refreshed successfully');
+              
+              // Close the bottom sheet
+              (ref as React.RefObject<BottomSheetModal>)?.current?.dismiss();
+            } catch (refreshError) {
+              console.error('❌ SubscriptionBottomSheet: Failed to refresh customer info:', refreshError);
+              // Still close the sheet even if refresh fails
+              (ref as React.RefObject<BottomSheetModal>)?.current?.dismiss();
+            }
+          }, 1000);
+        } else {
+          console.log('❌ SubscriptionBottomSheet: Subscription cancelled or failed');
+        }
+      } catch (error) {
+        console.error('❌ SubscriptionBottomSheet: Paywall error:', error);
+        Alert.alert('Erro', 'Não foi possível abrir a tela de assinatura. Tente novamente.');
+      } finally {
+        setIsPresentingPaywall(false);
+      }
+    };
+
+    // Get current subscription plan (only one card)
+    const getCurrentSubscriptionPlan = () => {
+      console.log('🔍 SubscriptionBottomSheet: getCurrentSubscriptionPlan called');
+      console.log('🔍 subscriptionLoading:', subscriptionLoading);
+      console.log('🔍 customerInfo:', customerInfo);
+      console.log('🔍 isPremium:', isPremium);
+      
+      if (subscriptionLoading) {
+        console.log('🔄 Returning loading state');
+        return {
+          title: 'Carregando...',
+          badge: 'CARREGANDO',
+          description: 'Verificando status da assinatura...',
+          isActive: false,
+          isClickable: false,
+          isLoading: true
+        };
+      }
+
+      // If no customer info, show free plan
+      if (!customerInfo) {
+        console.log('❌ No customer info, showing free plan');
+        return {
+          title: 'Sem Plano',
+          badge: 'ASSINAR AGORA',
+          description: 'Acesse recursos premium para maximizar seus resultados',
+          isActive: false,
+          isClickable: true,
+          isLoading: false
+        };
+      }
+
+      // Check for active subscriptions
+      const activeSubscriptions = customerInfo.activeSubscriptions;
+      console.log('🔍 activeSubscriptions:', activeSubscriptions);
+      
+      // Active yearly plan
+      if (activeSubscriptions.includes('forkfit_yearly_dev') || activeSubscriptions.includes('forkfit_yearly')) {
+        const expirationDate = customerInfo.latestExpirationDate;
+        const formattedDate = expirationDate ? new Date(expirationDate).toLocaleDateString('pt-BR', {
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric'
+        }) : '';
+        
+        console.log('✅ Found yearly subscription, showing annual plan');
+        return {
+          title: 'Plano Anual',
+          badge: 'ATIVO',
+          description: `Válido até: ${formattedDate}`,
+          isActive: true,
+          isClickable: false,
+          isLoading: false
+        };
+      }
+      
+      // Active monthly plan
+      if (activeSubscriptions.includes('forkfit_monthly_dev') || activeSubscriptions.includes('forkfit_monthly')) {
+        const expirationDate = customerInfo.latestExpirationDate;
+        const formattedDate = expirationDate ? new Date(expirationDate).toLocaleDateString('pt-BR', {
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric'
+        }) : '';
+        
+        console.log('✅ Found monthly subscription, showing monthly plan');
+        return {
+          title: 'Plano Mensal',
+          badge: 'ATIVO',
+          description: `Válido até: ${formattedDate}`,
+          isActive: true,
+          isClickable: false,
+          isLoading: false
+        };
+      }
+      
+      // No active subscription - show free plan
+      console.log('❌ No active subscription found, showing free plan');
+      return {
+        title: 'Sem Plano',
+        badge: 'ASSINAR AGORA',
+        description: 'Acesse recursos premium para maximizar seus resultados',
+        isActive: false,
+        isClickable: true,
+        isLoading: false
+      };
+    };
+
+    const currentPlan = getCurrentSubscriptionPlan();
+
+    // Debug effect to log changes in subscription state
+    useEffect(() => {
+      console.log('🔄 SubscriptionBottomSheet: Subscription state changed');
+      console.log('🔄 subscriptionLoading:', subscriptionLoading);
+      console.log('🔄 isPremium:', isPremium);
+      console.log('🔄 customerInfo:', customerInfo ? {
+        activeSubscriptions: customerInfo.activeSubscriptions,
+        latestExpirationDate: customerInfo.latestExpirationDate,
+        entitlementsActive: Object.keys(customerInfo.entitlements.active)
+      } : null);
+    }, [subscriptionLoading, isPremium, customerInfo]);
+
+    const handleClose = () => {
+      (ref as React.RefObject<BottomSheetModal>)?.current?.dismiss();
+    };
+
+    return (
+      <BottomSheetModal
+        ref={ref}
+        index={0}
+        snapPoints={snapPoints}
+        handleIndicatorStyle={{ backgroundColor: BORDER_LIGHT }}
+        backgroundStyle={{ backgroundColor: OFF_WHITE }}
+      >
+        <BottomSheetScrollView contentContainerStyle={styles.contentContainer}>
+          {/* Header */}
+          <View style={styles.headerRow}>
+            <View style={styles.headerContent}>
+              <Text style={styles.title}>Gerenciar Assinatura</Text>
+              <Text style={styles.subtitle}>Plano atual</Text>
+            </View>
+            <TouchableOpacity onPress={handleClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+              <FontAwesome6 name="xmark" size={22} color={CORAL} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Plan Card */}
+          <TouchableOpacity
+            style={[
+              styles.planCard,
+              currentPlan.isClickable && styles.clickableCard
+            ]}
+            onPress={currentPlan.isClickable ? handlePresentPaywall : undefined}
+            disabled={!currentPlan.isClickable || isPresentingPaywall}
+          >
+            <View style={styles.planContent}>
+              <View style={styles.planHeader}>
+                <Text style={styles.planTitle}>{currentPlan.title}</Text>
+                <View style={[
+                  styles.planBadge,
+                  currentPlan.isActive ? styles.activeBadge : 
+                  currentPlan.badge === 'ASSINAR AGORA' ? styles.signupBadge :
+                  styles.loadingBadge
+                ]}>
+                  <Text style={styles.planBadgeText}>{currentPlan.badge}</Text>
+                </View>
+              </View>
+              <Text style={styles.planDescription}>
+                {currentPlan.description}
+              </Text>
+              {currentPlan.isActive && (
+                <View style={styles.planFooter}>
+                  <Text style={styles.planFooterText}>
+                    Renovação automática
+                  </Text>
+                </View>
+              )}
+              {currentPlan.isClickable && (
+                <View style={styles.planFooter}>
+                  <Text style={styles.planFooterText}>
+                    {isPresentingPaywall ? 'Abrindo...' : 'Toque para assinar'}
+                  </Text>
+                </View>
+              )}
+            </View>
+          </TouchableOpacity>
+        </BottomSheetScrollView>
+      </BottomSheetModal>
+    );
+  }
+);
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 20,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 24,
+    paddingTop: 8,
+  },
+  headerContent: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: TEXT_DARK,
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: TEXT_LIGHT,
+  },
+  planCard: {
+    backgroundColor: '#f8fafc',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: BORDER_LIGHT,
+    overflow: 'hidden',
+  },
+  clickableCard: {
+    backgroundColor: '#ffffff',
+    borderColor: CORAL,
+    borderWidth: 2,
+    shadowColor: CORAL,
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  planContent: {
+    padding: 20,
+  },
+  planHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 8,
+  },
+  planTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: TEXT_DARK,
+    flex: 1,
+    marginRight: 12,
+  },
+  planBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    minWidth: 80,
+    alignItems: 'center',
+  },
+  activeBadge: {
+    backgroundColor: '#10b981',
+  },
+  signupBadge: {
+    backgroundColor: CORAL,
+  },
+  loadingBadge: {
+    backgroundColor: '#6b7280',
+  },
+  planBadgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#ffffff',
+    textTransform: 'uppercase',
+  },
+  planDescription: {
+    fontSize: 14,
+    color: TEXT_LIGHT,
+    lineHeight: 20,
+    marginBottom: 12,
+  },
+  planFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  planFooterText: {
+    fontSize: 14,
+    color: '#10b981',
+    fontWeight: '500',
+  },
+});
+
+SubscriptionBottomSheet.displayName = 'SubscriptionBottomSheet';

--- a/contexts/SubscriptionContext.tsx
+++ b/contexts/SubscriptionContext.tsx
@@ -111,11 +111,23 @@ export const SubscriptionProvider: React.FC<SubscriptionProviderProps> = ({ chil
 
   const refreshCustomerInfo = async (): Promise<void> => {
     try {
+      console.log('🔄 SubscriptionContext: Refreshing customer info...');
       const customerInfo = await revenueCatService.getCustomerInfo();
+      const hasActiveSubscription = revenueCatService.hasActiveSubscription(customerInfo);
+      
+      console.log('🔄 SubscriptionContext: Updated customer info:', {
+        activeSubscriptions: customerInfo.activeSubscriptions,
+        entitlementsActive: Object.keys(customerInfo.entitlements.active),
+        latestExpirationDate: customerInfo.latestExpirationDate,
+        hasActiveSubscription
+      });
+      
       setCustomerInfo(customerInfo);
-      setIsPremium(revenueCatService.hasActiveSubscription(customerInfo));
+      setIsPremium(hasActiveSubscription);
+      
+      console.log('✅ SubscriptionContext: Customer info refreshed successfully');
     } catch (error) {
-      console.error('Failed to refresh customer info:', error);
+      console.error('❌ SubscriptionContext: Failed to refresh customer info:', error);
       throw error;
     }
   };


### PR DESCRIPTION
setting page updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Subscription and Language bottom sheets to Settings, replaces inline plan card with a paywall-integrated sheet, and links Privacy/Terms while improving subscription refresh logging.
> 
> - **Settings (`app/(app)/(tabs)/settings.tsx`)**:
>   - Replace inline "Plano Atual" card with `SubscriptionBottomSheet`; remove associated styles and `useSubscription` usage in screen.
>   - Add `LanguageBottomSheet` and wire "Idioma" and "Gerenciar Assinatura" rows to present their sheets.
>   - Keep existing notifications, privacy, and help flows; integrate new sheet refs.
> - **New Components**:
>   - `components/SubscriptionBottomSheet.tsx`: Shows current plan (monthly/annual/none), presents paywall via `useSubscription`, refreshes customer info, and dismisses on success.
>   - `components/LanguageBottomSheet.tsx`: Displays current language and info; non-interactive for now.
> - **Privacy (`components/PrivacyBottomSheet.tsx`)**:
>   - Add external links to Privacy Policy and Terms of Use with styled link buttons.
> - **Subscription Context (`contexts/SubscriptionContext.tsx`)**:
>   - Enhance `refreshCustomerInfo` with logging and explicit `isPremium` updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ea9edcff5cd4fbc5e2d707a5edd387e46aa83b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->